### PR TITLE
refactor: place the export page under the tools menu item

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,5 +50,5 @@ build {
 }
 
 halo {
-    version = "2.11"
+    version = "2.12"
 }

--- a/console/package.json
+++ b/console/package.json
@@ -8,9 +8,9 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@halo-dev/api-client": "^2.11.0",
+    "@halo-dev/api-client": "^2.12.0",
     "@halo-dev/components": "^1.10.0",
-    "@halo-dev/console-shared": "^2.11.0",
+    "@halo-dev/console-shared": "^2.12.0",
     "@tanstack/vue-query": "^4.29.1",
     "@vueuse/router": "^10.7.1",
     "axios": "^1.6.5",
@@ -19,7 +19,7 @@
     "vue": "^3.4.5"
   },
   "devDependencies": {
-    "@halo-dev/ui-plugin-bundler-kit": "^1.0.0",
+    "@halo-dev/ui-plugin-bundler-kit": "^2.12.0",
     "@iconify/json": "^2.2.165",
     "@rushstack/eslint-patch": "^1.6.1",
     "@types/jsdom": "^20.0.1",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -6,14 +6,14 @@ settings:
 
 dependencies:
   '@halo-dev/api-client':
-    specifier: ^2.11.0
-    version: 2.11.0
+    specifier: ^2.12.0
+    version: 2.12.0
   '@halo-dev/components':
     specifier: ^1.10.0
     version: 1.10.0(vue-router@4.2.5)(vue@3.4.5)
   '@halo-dev/console-shared':
-    specifier: ^2.11.0
-    version: 2.11.0(vue-router@4.2.5)(vue@3.4.5)
+    specifier: ^2.12.0
+    version: 2.12.0(vue-router@4.2.5)(vue@3.4.5)
   '@tanstack/vue-query':
     specifier: ^4.29.1
     version: 4.37.1(vue@3.4.5)
@@ -35,8 +35,8 @@ dependencies:
 
 devDependencies:
   '@halo-dev/ui-plugin-bundler-kit':
-    specifier: ^1.0.0
-    version: 1.0.0(vite@3.2.7)
+    specifier: ^2.12.0
+    version: 2.12.0(vite@3.2.7)
   '@iconify/json':
     specifier: ^2.2.165
     version: 2.2.165
@@ -593,8 +593,8 @@ packages:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: false
 
-  /@halo-dev/api-client@2.11.0:
-    resolution: {integrity: sha512-i3PFETsPdHYnTgk3jORu00t43/rCesmqpdZg38/Hq2AdgxhPkE7rghYGdoZRLdanvVC0HM1Axn18Zd7kdizxVA==}
+  /@halo-dev/api-client@2.12.0:
+    resolution: {integrity: sha512-W/FmwtdXvq/BSwi2VMYBPzV86SmUjjn/1RO3pzyBOp8KwZM97vVVPJwYhT7IUB+W7q9HtDBUlvcFS8M0bX0RaA==}
     dev: false
 
   /@halo-dev/components@1.10.0(vue-router@4.2.5)(vue@3.4.5):
@@ -610,19 +610,19 @@ packages:
       - '@nuxt/kit'
     dev: false
 
-  /@halo-dev/console-shared@2.11.0(vue-router@4.2.5)(vue@3.4.5):
-    resolution: {integrity: sha512-XDyoHsueVgQOvMTDm4Fx3qKzCjXd7bI9eC0DFuw3w85Y3LQeHgrJfbXRlMRCTTZhe3kgpBOra4JjByyFFWa/Cw==}
+  /@halo-dev/console-shared@2.12.0(vue-router@4.2.5)(vue@3.4.5):
+    resolution: {integrity: sha512-coxKxjKD5jYednO18c3KDlp+0+QfxS+FVOm5oS/EPi3mw7So8wFZ82TF/zv0p5JAsKc9XKHQ7gusRckA3K0zww==}
     peerDependencies:
       vue: ^3.3.4
       vue-router: ^4.2.4
     dependencies:
-      '@halo-dev/api-client': 2.11.0
+      '@halo-dev/api-client': 2.12.0
       vue: 3.4.5(typescript@4.7.4)
       vue-router: 4.2.5(vue@3.4.5)
     dev: false
 
-  /@halo-dev/ui-plugin-bundler-kit@1.0.0(vite@3.2.7):
-    resolution: {integrity: sha512-K6D2jPJnLLl0gsiTzRoqXyr4pDl0+venTHW0hbk+cTuB9TNMEEFelBvYefrKQNjK9NpW4wVqviw4QLDXrrY3Vw==}
+  /@halo-dev/ui-plugin-bundler-kit@2.12.0(vite@3.2.7):
+    resolution: {integrity: sha512-3558qzH5RN9pB2j0ZonuIxX3cw8lh870cWpPPHjkDxTIjKt+aO5tjKhcqKlFL853jdx9nHIIS+nMDCeqjejpxw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^4.0.0 || ^5.0.0

--- a/console/src/index.ts
+++ b/console/src/index.ts
@@ -10,14 +10,15 @@ export default definePlugin({
     components: {},
     routes: [
         {
-            parentName: "Root",
+            parentName: "ToolsRoot",
             route: {
-                path: "/export2doc",
+                path: "export2doc",
                 name: "export2doc",
                 component: HomeView,
                 meta: {
                     title: "文章导入导出",
                     searchable: true,
+                    description: "导出文章为 Markdown、HTML 文件，同时支持导入 Markdown 文件",
                     permissions: ["plugin:export2doc:view"],
                     menu: {
                         name: "文章导入导出",

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -5,7 +5,7 @@ metadata:
   name: export2doc
 spec:
   enabled: true
-  requires: ">=2.11.0"
+  requires: ">=2.12.0"
   author:
     name: Lyn4ever
     website: https://jhacker.cn


### PR DESCRIPTION
将导入导出页面的入口放置在工具菜单项下作为子菜单项。

需要注意，此改动需要 2.12 的支持，所以我同时将 requires 改为了 `>=2.12.0`

<img width="1920" alt="image" src="https://github.com/Lyn4ever29/halo-plugin-export-md/assets/21301288/560c1223-a22a-482b-8181-7dd9cbb1d7a3">

<img width="1920" alt="image" src="https://github.com/Lyn4ever29/halo-plugin-export-md/assets/21301288/4e9ce87d-01f8-4873-a563-bcafef4d9a79">
